### PR TITLE
Nitpicks

### DIFF
--- a/NTPtimeESP.h
+++ b/NTPtimeESP.h
@@ -2,7 +2,7 @@
 
    NTPtime for ESP8266
    This routine gets the unixtime from a NTP server and adjusts it to the time zone and the
-   Middle European summer time if requested
+   Middle European summer time or US daylight savings time if requested
 
   Author: Andreas Spiess V1.0 2016-6-28
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This library returns the queries the NTP time service and returns the actual time in a structure:
 
-```
+```c
 struct strDateTime
 {
 
@@ -18,4 +18,5 @@ struct strDateTime
 };
 ```
 
-The time can be automatically adjusted by time zone and European summer time. It runs on ESP8266 and needs an internet connection.
+The time can be automatically adjusted by time zone and European summer time or US daylight savings time.
+It runs on ESP8266 and needs an internet connection.


### PR DESCRIPTION
Assorted minor nitpicks:

1. Documentation and comments: mention that US daylight savings time is
   supported.

2. Fixed typos in defines.

3. Assorted whitespace fixes.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>